### PR TITLE
refactor: change input parsing logic to simplify EOF handling

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,15 +107,10 @@ where
         Ok(0) => Ok(None), // EOF encountered
         Ok(_) => {
             let trimmed_input = input.trim_end_matches('\r').trim_end_matches('\n');
-            if trimmed_input.is_empty() && input.ends_with('\n') {
-                // Consider an empty line as EOF, returning None
-                Ok(None)
-            } else {
-                trimmed_input
-                    .parse::<T>()
-                    .map(Some)
-                    .map_err(InputError::Parse)
-            }
+            trimmed_input
+                .parse::<T>()
+                .map(Some)
+                .map_err(InputError::Parse)
         }
         Err(e) => Err(InputError::Io(e)),
     }


### PR DESCRIPTION
Following @lebensterben's opinion this PR do the following:

When prompted for an input, if the user just press the carriage returns, the program should get "\n" instead of "". To have the program to receive empty input, the user needs to press Ctrl-D to close the input steam.

That's to say:

 -   "\n" translates to an empty string as the input
 -   "C-D" translates to no input.

